### PR TITLE
Add Scoop installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ request it be added to that project _first_.
 This will only work for Windows. If you are using another OS, you will need to
 follow the Advanced instructions below.
 
+# Install through Scoop
+
+Alternatively, on Windows, [Scoop](https://scoop.sh/) package manager can be used to install and update this tool: `scoop install gog-galaxy-plugin-downloader`.
+
 # Advanced Usage
 
 ## Requirements


### PR DESCRIPTION
Hi, I have added this tool to Scoop (https://github.com/lukesampson/scoop-extras/pull/2975), which makes it easier to install and update for people who use it. This changes absolutely nothing for you, Scoop will just automatically use the latest GitHub release (except pre-releases).