### PR TITLE
Updated the Rockstar plugin to v0.3.4.

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -40,7 +40,7 @@ plugins:
         url: 'https://github.com/Ertego/gog-galaxy-itch.io/releases/download/${version}/itch_0_0_2.zip'
         archive_path: 'itch/'
     rockstar:
-        version: '0.2.2'
+        version: '0.3'
         url: 'https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/releases/download/v${version}/plugin.zip'
         archive_path: 'Rockstar/'
     twitch:

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -39,7 +39,7 @@ plugins:
         url: 'https://github.com/Ertego/gog-galaxy-itch.io/releases/download/${version}/itch_0_0_2.zip'
         archive_path: 'itch/'
     rockstar:
-        version: '0.3.2'
+        version: '0.3.3'
         url: 'https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/releases/download/v${version}/plugin.zip'
         archive_path: 'Rockstar/'
     twitch:

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -39,7 +39,7 @@ plugins:
         url: 'https://github.com/Ertego/gog-galaxy-itch.io/releases/download/${version}/itch_0_0_2.zip'
         archive_path: 'itch/'
     rockstar:
-        version: '0.3.3'
+        version: '0.3.4'
         url: 'https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/releases/download/v${version}/plugin.zip'
         archive_path: 'Rockstar/'
     twitch:

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -40,7 +40,7 @@ plugins:
         url: 'https://github.com/Ertego/gog-galaxy-itch.io/releases/download/${version}/itch_0_0_2.zip'
         archive_path: 'itch/'
     rockstar:
-        version: '0.3'
+        version: '0.3.1'
         url: 'https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/releases/download/v${version}/plugin.zip'
         archive_path: 'Rockstar/'
     twitch:

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -39,7 +39,7 @@ plugins:
         url: 'https://github.com/Ertego/gog-galaxy-itch.io/releases/download/${version}/itch_0_0_2.zip'
         archive_path: 'itch/'
     rockstar:
-        version: '0.3.1'
+        version: '0.3.2'
         url: 'https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/releases/download/v${version}/plugin.zip'
         archive_path: 'Rockstar/'
     twitch:


### PR DESCRIPTION
As a side note, @FriendsOfGalaxy now maintains their own fork of the Rockstar plugin, which can be found at https://github.com/FriendsOfGalaxy/galaxy-integration-rockstar. I would suggest that you add this link instead of the current one after the awesome-gog-galaxy list is updated to include it. Just note that updated releases for this fork tend to be released some time after releases for the current repository.